### PR TITLE
Resolving architectural conflicts within code logic from two previous merged branches & unloading the main function

### DIFF
--- a/loaders/base_loader.py
+++ b/loaders/base_loader.py
@@ -1,9 +1,10 @@
+import os, traceback
 from abc import ABC, abstractmethod
-from datasets import load_dataset, Dataset, concatenate_datasets
-import sys, os
+from datasets import load_dataset, Dataset
+from .utils import load_local
 
 class BaseLoader(ABC):
-    """Loader commun"""
+    """Common Loader"""
 
     def __init__(self, source: str, path: str, subset: str = None, source_split: str = "train"):
         self.source     = source
@@ -14,69 +15,20 @@ class BaseLoader(ABC):
 
     @abstractmethod
     def postprocess(self, dataset: Dataset, subset: str = None, split: str = "train") -> Dataset:
-        """Spécifique au dataset : renommage de colonnes, filtrage, etc."""
+        """Specific to each dataset: column renaming, filtering, etc."""
         ...
 
-    def load_local(self, split):
-        if os.path.isdir(self.path): # Check if path is a local directory
-            print(f"Loading from local path: {self.path} for split: {split}")
-            all_texts = []
-            for root, dirs, files in os.walk(self.path):
-                print(f"Searching for .txt files in {root}...")
-                for file_name in files:
-                    if file_name.endswith(".txt"):
-                        file_path = os.path.join(root, file_name)
-                        try:
-                            with open(file_path, 'r', encoding='utf-8') as f:
-                                all_texts.append(f.read())
-                        except Exception as e:
-                            print(f"Error reading file {file_path}: {e}")
-
-            if not all_texts:
-                print(f"No .txt files found in {self.path} or its subdirectories.")
-                return []
-
-            raw_dataset_items = [{"text": text_content} for text_content in all_texts]
-            return raw_dataset_items
-
-        else:
-            raise FileNotFoundError(f"{self.path} is not a local directory.")
-
     def load(self) -> Dataset:
-        # subsets = self.subset if isinstance(self.subset, list) else [self.subset]
-        # splits = self.split if isinstance(self.split, list) else [self.split]
-        # all_dirs = []
-        # for subset in subsets:
-        #     all_splits = []
-        #     for split in splits:
-        #         try:
-        #             tmp_ds = load_dataset(
-        #                 path=self.path,
-        #                 data_dir=subset,
-        #                 split=split,
-        #                 streaming=self.stream,
-        #                 trust_remote_code=True
-        #             )
-        #             tmp_ds = self.postprocess(dataset=tmp_ds, subset=subset, split=split)
-        #             all_splits.append(tmp_ds)
-        tmp_ds = load_dataset(
-            path=self.path, 
-            data_dir=self.subset, 
-            split=self.split, 
-            streaming=self.stream, 
-            trust_remote_code=True
-        )
-        ds = self.postprocess(dataset=tmp_ds, subset=self.subset, split=self.split)
-        #         except Exception as e:
-        #             print(f"Unavailable data split \"{split}\" for data_dir \"{subset}\".")
-        #             continue
-        #     if len(all_splits) > 0:
-        #         all_dirs += all_splits
-        #     else:
-        #         print(f"No data splits available for data_dir \"{subset}\" (probably unexistent data_dir).")
-        # if len(all_dirs) > 0:
-        #     return concatenate_datasets(all_dirs)
-        # else:
-        #     sys.tracebacklimit = 0 
-        #     raise RuntimeError(f"No data was loaded for dataset \"{self.source}\".")
-        return ds
+        load_fn = load_local if os.path.isdir(self.path) else load_dataset
+        try:
+            tmp_ds = load_fn(
+                path=self.path, 
+                data_dir=self.subset, 
+                split=self.split, 
+                streaming=self.stream, 
+                trust_remote_code=True
+            )
+            ds = self.postprocess(dataset=tmp_ds, subset=self.subset, split=self.split)
+            return ds
+        except Exception as e:
+            raise RuntimeError(f"Impossible to load this dataset:\n {traceback.format_exc()}")

--- a/loaders/cas.py
+++ b/loaders/cas.py
@@ -1,64 +1,18 @@
-import os
-from datasets import Dataset,concatenate_datasets
-from .base_loader import BaseLoader # Assuming BaseLoader handles the overall loading flow
+from datasets import Dataset
+from .base_loader import BaseLoader
 
 class CAS(BaseLoader):
-
-    def load(self) -> Dataset:
-        """
-        Overlaods the load method to handle local data loading for the CAS dataset.
-        """
-        subsets = self.subset if isinstance(self.subset, list) else [self.subset]
-        splits = self.split if isinstance(self.split, list) else [self.split]
-
-        all_dirs = []
-        for subset in subsets:
-            all_splits = []
-            for split in splits:
-                try:
-                    print(f"INFO: Attempting to use custom load_data method for {self.source}, subset {self.subset}, split {split}")
-                    rawData = self.load_local(split=split)
-                    assert rawData is not None, f"WARNING: Custom load_data for {self.source} returned None for split {split}"
-                    tmp_ds = self.postprocess(dataset=rawData, subset=subset, split=split)
-                    all_splits.append(tmp_ds)
-                except Exception as e:
-                    print(f"Error during data loading or postprocessing for {self.source}, subset '{subset}', split '{split}'. Path: '{self.path}'. Error: {e}")
-                    print(f"Unavailable data split \"{split}\" for data_dir \"{subset}\" (or error in custom load_data).")
-                    continue
-            if len(all_splits) > 0:
-                all_dirs += all_splits
-            else:
-                print(f"No data splits available for data_dir \"{subset}\" (probably unexistent data_dir).")
-        if len(all_dirs) > 0:
-            return concatenate_datasets(all_dirs)
-        else:
-            raise RuntimeError(f"No data was loaded for dataset \"{self.source}\".")
-        return ds
-
-
     def postprocess(self, dataset, subset, split):
-        '''
+        """
         Processes the raw Hugging Face dataset OR locally loaded data for Mantra GSC French.
         If local: 'dataset' will be the list of dicts from load_data.
         If HF: 'dataset' is expected to be loaded via:
         datasets.load_dataset(path="bigbio/mantra_gsc", name="mantra_gsc_fr_source", split=split)
-        '''
-        processed_texts = []
-
-        for item in dataset:
-            if 'text' in item and isinstance(item['text'], str):
-                processed_texts.append(item['text'])
-            else:
-                raise ValueError(f"Could not find 'text' string in item.")
-
-        if not processed_texts and not (isinstance(dataset, list) and len(dataset) == 0 and os.path.isdir(self.path)):
-            print(f"Warning: No texts were processed for subset '{subset}', split '{split}'. Check data source and loading logic.")
-
+        """
         res = {
-            "text": processed_texts,
-            "source": [self.source] * len(processed_texts), # self.source should be "MANTRA_GSC"
-            "subset": [subset] * len(processed_texts),       # subset should be "French"
-            "source_split": [split] * len(processed_texts)   # split should be "train"
+            "text": list(dataset['text']),
+            "source": [self.source] * len(dataset), # self.source should be "MANTRA_GSC"
+            "subset": [subset] * len(dataset),       # subset should be "French"
+            "source_split": [split] * len(dataset)   # split should be "train"
         }
-
         return Dataset.from_dict(res)

--- a/loaders/mantra_gsc.py
+++ b/loaders/mantra_gsc.py
@@ -1,64 +1,18 @@
-import os
-from datasets import Dataset,concatenate_datasets
-from .base_loader import BaseLoader # Assuming BaseLoader handles the overall loading flow
+from datasets import Dataset
+from .base_loader import BaseLoader
 
 class MANTRA_GSC(BaseLoader):
-
-    def load(self) -> Dataset:
-        """
-        Overlaods the load method to handle local data loading for the MANTRA GSC dataset.
-        """
-        subsets = self.subset if isinstance(self.subset, list) else [self.subset]
-        splits = self.split if isinstance(self.split, list) else [self.split]
-
-        all_dirs = []
-        for subset in subsets:
-            all_splits = []
-            for split in splits:
-                try:
-                    print(f"INFO: Attempting to use custom load_data method for {self.source}, subset {self.subset}, split {split}")
-                    rawData = self.load_local(split=split)
-                    assert rawData is not None, f"WARNING: Custom load_data for {self.source} returned None for split {split}"
-                    tmp_ds = self.postprocess(dataset=rawData, subset=subset, split=split)
-                    all_splits.append(tmp_ds)
-                except Exception as e:
-                    print(f"Error during data loading or postprocessing for {self.source}, subset '{subset}', split '{split}'. Path: '{self.path}'. Error: {e}")
-                    print(f"Unavailable data split \"{split}\" for data_dir \"{subset}\" (or error in custom load_data).")
-                    continue
-            if len(all_splits) > 0:
-                all_dirs += all_splits
-            else:
-                print(f"No data splits available for data_dir \"{subset}\" (probably unexistent data_dir).")
-        if len(all_dirs) > 0:
-            return concatenate_datasets(all_dirs)
-        else:
-            raise RuntimeError(f"No data was loaded for dataset \"{self.source}\".")
-        return ds
-
-
     def postprocess(self, dataset, subset, split):
-        '''
+        """
         Processes the raw Hugging Face dataset OR locally loaded data for Mantra GSC French.
         If local: 'dataset' will be the list of dicts from load_data.
         If HF: 'dataset' is expected to be loaded via:
         datasets.load_dataset(path="bigbio/mantra_gsc", name="mantra_gsc_fr_source", split=split)
-        '''
-        processed_texts = []
-
-        for item in dataset:
-            if 'text' in item and isinstance(item['text'], str):
-                processed_texts.append(item['text'])
-            else:
-                raise ValueError(f"Could not find 'text' string in item.")
-
-        if not processed_texts and not (isinstance(dataset, list) and len(dataset) == 0 and os.path.isdir(self.path)):
-            print(f"Warning: No texts were processed for subset '{subset}', split '{split}'. Check data source and loading logic.")
-
+        """
         res = {
-            "text": processed_texts,
-            "source": [self.source] * len(processed_texts), # self.source should be "MANTRA_GSC"
-            "subset": [subset] * len(processed_texts),       # subset should be "French"
-            "source_split": [split] * len(processed_texts)   # split should be "train"
+            "text": list(dataset['text']),
+            "source": [self.source] * len(dataset), # self.source should be "MANTRA_GSC"
+            "subset": [subset] * len(dataset),       # subset should be "French"
+            "source_split": [split] * len(dataset)   # split should be "train"
         }
-
         return Dataset.from_dict(res)

--- a/loaders/utils.py
+++ b/loaders/utils.py
@@ -1,0 +1,54 @@
+import os, sys, yaml
+from typing import Union
+from pathlib import Path
+from datasets import Dataset
+from argparse import ArgumentParser
+
+
+def str2bool(v):
+    if v.lower() in ("yes", "true", "t", "1"):
+        return True
+    else:
+        return False
+
+
+def parse():
+    parser = ArgumentParser()
+    parser.add_argument("--hf_token", type=str, default="")
+    parser.add_argument("--push_to_hub", type=str2bool, default=False)
+    parser.add_argument("--use_all_sources", type=str2bool, default=True)
+    parser.add_argument("--source", type=str, default="")
+    parser.add_argument("--make_commercial_version", type=str2bool, default=True)
+    return parser.parse_args()
+
+
+def load_config(path="config/datasets.yaml"):
+    with open(path, "r") as f:
+        return yaml.safe_load(f)["datasets"]
+
+
+def load_local(
+    path: Union[str, Path], 
+    split: Union[str, list], 
+    data_dir: Union[str, list] = None, 
+    streaming: bool = False, 
+    trust_remote_code: bool = True
+) -> list:
+    print(f"Loading from local path: {path} for split: {split}")
+    all_texts = []
+    for root, dirs, files in os.walk(path):
+        print(f"Searching for .txt files in {root}...")
+        for file_name in files:
+            if file_name.endswith(".txt"):
+                file_path = os.path.join(root, file_name)
+                try:
+                    with open(file_path, 'r', encoding='utf-8') as f:
+                        all_texts.append(f.read())
+                except Exception as e:
+                    print(f"Error reading file {file_path}: {e}")
+    if not all_texts:
+        sys.tracebacklimit = 0
+        raise RuntimeError(f"No .txt files found in {path} or its subdirectories.")
+    else:
+        # raw_dataset_items = [{"text": text_content} for text_content in all_texts]
+        return Dataset.from_dict({'text': all_texts}) 

--- a/loaders/utils.py
+++ b/loaders/utils.py
@@ -22,9 +22,42 @@ def parse():
     return parser.parse_args()
 
 
-def load_config(path="config/datasets.yaml"):
+def read_config(path="config/datasets.yaml"):
     with open(path, "r") as f:
         return yaml.safe_load(f)["datasets"]
+    
+
+def load_config(args):
+    all_cfg = read_config()
+
+    if not args.use_all_sources:
+        for cfg in all_cfg:        
+            if args.source == cfg['source']:
+                all_cfg = [cfg]
+                break
+        else: 
+            sys.tracebacklimit = 0 
+            raise RuntimeError(f"No available dataset named {args.source} in config.")
+
+    if args.make_commercial_version:
+        print("\nCOMMERCIAL VERSION")
+        print(f"Available datasets in config: {[cfg['source'] for cfg in all_cfg]}")
+        tmp_cfg = []
+        for cfg in all_cfg:
+            if cfg['commercial_use']:
+                tmp_cfg.append(cfg)
+        all_cfg = tmp_cfg
+        print(f"Remaining datasets after commercial use filtering: {[cfg['source'] for cfg in all_cfg]}\n")
+    else:
+        print("\nNON-COMMERCIAL VERSION")
+        print(f"Available datasets in config: {[cfg['source'] for cfg in all_cfg]}\n")
+    
+    if len(all_cfg) < 1:
+        sys.tracebacklimit = 0 
+        raise RuntimeError(f"No available dataset(s) for given parametrization (check commercial use and source(s) given).")
+    
+    return all_cfg
+
 
 
 def load_local(

--- a/main.py
+++ b/main.py
@@ -13,33 +13,7 @@ def main():
     with open(args.hf_token, 'r') as f:
         hf_token = f.read()
     HfFolder.save_token(hf_token)
-    all_cfg = load_config()
-
-    if not args.use_all_sources:
-        for cfg in all_cfg:        
-            if args.source == cfg['source']:
-                all_cfg = [cfg]
-                break
-        else: 
-            sys.tracebacklimit = 0 
-            raise RuntimeError(f"No available dataset named {args.source} in config.")
-
-    if args.make_commercial_version:
-        print("\nCOMMERCIAL VERSION")
-        print(f"Available datasets in config: {[cfg['source'] for cfg in all_cfg]}")
-        tmp_cfg = []
-        for cfg in all_cfg:
-            if cfg['commercial_use']:
-                tmp_cfg.append(cfg)
-        all_cfg = tmp_cfg
-        print(f"Remaining datasets after commercial use filtering: {[cfg['source'] for cfg in all_cfg]}\n")
-    else:
-        print("\nNON-COMMERCIAL VERSION")
-        print(f"Available datasets in config: {[cfg['source'] for cfg in all_cfg]}\n")
-    
-    if len(all_cfg) < 1:
-        sys.tracebacklimit = 0 
-        raise RuntimeError(f"No available dataset(s) for given parametrization (check commercial use and source(s) given).")
+    all_cfg = load_config(args=args)
 
     for cfg in all_cfg:
         print(f"Loading dataset {cfg["source"]}: using {REGISTRY[cfg["source"]]}")


### PR DESCRIPTION
**Changes**
- Creation of `utils.py` in which config and data loading-related functions are implemented to shorten the rest of the code.
- Adapted the `main.py` and `base_loader.py` scripts to the above changes.
- As `cas.py` and `mantra_gsc.py` scripts where built upon an *older* version of the base loader that included the loops on the subsets and splits of each dataset (the newer version was pushed in parallel of the CAS and MANTRA-GSC local loaders implementation), they were adapted to this new structure.

**Tests** (for the following tests: HAL and HAS configurations in `config/datasets.yaml` were commented out as they are not supported for now; for faster loading I tested once with DEFT2021 and FRENCHMEDMCQA can be commented out; it is normal if the last two tests should raise an error)
- `python main.py --hf_token /Users/armandviolle/Developer/partages/hf-token.txt --make_commercial_version True`
- `python main.py --hf_token /Users/armandviolle/Developer/partages/hf-token.txt --make_commercial_version False`
- `python main.py --hf_token /Users/armandviolle/Developer/partages/hf-token.txt --make_commercial_version False` changing the `source_split` argument of the WMT16 config from `"train"` to `["train", "validation"]`, which should trigger the printing of the message *Unavailable data split "validation" for data_dir "en-fr".* in the logs.
- `python main.py --hf_token /Users/armandviolle/Developer/partages/hf-token.txt --make_commercial_version False --use_all_sources False --source "CAS"`
- `python main.py --hf_token /Users/armandviolle/Developer/partages/hf-token.txt --make_commercial_version True --use_all_sources False --source "CAS"`
- `python main.py --hf_token /Users/armandviolle/Developer/partages/hf-token.txt --make_commercial_version False --use_all_sources False --source "HAL"`

The tests' logs are available below :)

[logs-tests-uniformization.log](https://github.com/user-attachments/files/20675667/logs-tests-uniformization.log)