### PR TITLE
Adding train/test split support for HF dataset

### DIFF
--- a/config/datasets.yaml
+++ b/config/datasets.yaml
@@ -4,21 +4,21 @@ datasets:
     path: "qanastek/WMT-16-PubMed"
     subset: "en-fr"
     source_split: "train"
-    target_split: 
+    target_split: "train"
     commercial_use: True
     comment: ""
   - source: DEFT2021
     path: "DrBenchmark/DEFT2021"
     subset:
     source_split: ["train", "validation", "test"]
-    target_split:     
+    target_split: "test"
     commercial_use: True
     comment: ""
   - source: FRENCHMEDMCQA
     path: "qanastek/frenchmedmcqa"
     subset:
     source_split: ["train", "validation", "test"]
-    target_split:     
+    target_split: "train"
     commercial_use: True
     comment: ""
   # From NACHOS
@@ -26,112 +26,112 @@ datasets:
     path: "datasets/HAL"
     subset: "NACHOS"
     source_split:
-    target_split: 
+    target_split: "train"
     commercial_use: True
     comment: ""
   - source: "HAS"
     path: "datasets/HAS"
     subset: "NACHOS"
     source_split:
-    target_split: 
+    target_split: "train"
     commercial_use: True
     comment: ""
   - source: "WIKIPEDIA"
     path: "datasets/WIKIPEDIA"
     subset: 
     source_split:
-    target_split: 
+    target_split: "train"
     commercial_use: True
     comment: ""
   - source: "EMEA_V3"
     path: "datasets/EMEA-V3"
     subset: "NACHOS"
     source_split:
-    target_split: 
+    target_split: "test"
     commercial_use: True
     comment: ""
   - source: "QUAERO"
     path: "datasets/Quaero"
     subset: "NACHOS"
     source_split:
-    target_split: 
+    target_split: "test"
     commercial_use: True
     comment: ""
   - source: "BDPM"
     path: "datasets/DBPM"
     subset: "NACHOS"
     source_split:
-    target_split: 
+    target_split: "train"
     commercial_use: True
     comment: ""
   - source: "ECDC_TM"
     path: "datasets/ECDC"
     subset: "NACHOS"
     source_split:
-    target_split: 
+    target_split: "train"
     commercial_use: True
     comment: ""
   - source: "QUALISCOPE"
     path: "datasets/ScopeSanteQualité"
     subset: "NACHOS"
     source_split:
-    target_split: 
+    target_split: "train"
     commercial_use: True
     comment: ""
   - source: "CNEDIMTS"
     path: "datasets/CNEDiMTS"
     subset: "NACHOS"
     source_split:
-    target_split: 
+    target_split: "train"
     commercial_use: True
     comment: ""
   - source: "WMT18_MEDLINE"
     path: "datasets/WMT-18-Medline"
     subset: "NACHOS"
     source_split:
-    target_split: 
+    target_split: "train"
     commercial_use: False
     comment: ""
   - source: "ISTEX"
     path: "datasets/ISTEX"
     subset: "NACHOS"
     source_split:
-    target_split: 
+    target_split: "train"
     commercial_use: True
     comment: ""
   - source: "CERIMES"
     path: "datasets/Cerimes"
     subset: "NACHOS"
     source_split:
-    target_split: 
+    target_split: "train"
     commercial_use: True
     comment: ""
   - source: "CLEAR"
     path: "datasets/CLEAR"
     subset: "NACHOS"
     source_split:
-    target_split: 
+    target_split: "test"
     commercial_use: False
     comment: ""
   - source: "ANSES_RCP"
     path: "datasets/ANSES_RCP"
     subset: "NACHOS"
     source_split:
-    target_split: 
+    target_split: "train"
     commercial_use: False
     comment: ""
   - source: "ANSES_SAISINE"
     path: "datasets/ANSES_SAISINE"
     subset: "NACHOS"
     source_split:
-    target_split: 
+    target_split: "train"
     commercial_use: False
     comment: ""
   - source: "E3C"
     path: "datasets/E3C-Corpus-2.0.0-French"
     subset: "NACHOS"
     source_split:
-    target_split: 
+    target_split: "test"
     commercial_use: False
     comment: ""
   # From dumps
@@ -139,34 +139,34 @@ datasets:
     path: "datasets/mantra_gsc" # local path
     subset: "French"
     source_split: "train"
-    target_split: 
+    target_split: "train"
     commercial_use: True
     comment: ""
   - source: CAS
     path: "datasets/cas" # local path
     subset: "French"
     source_split: "train"
-    target_split: 
+    target_split: "train"
     commercial_use: False
     comment: ""
   - source: FRASIMED
     path: "datasets/frasimed" # local path
     subset: "French"
     source_split: "train"
-    target_split: 
+    target_split: "train"
     commercial_use: False
     comment: ""
   - source: PXCORPUS
     path: "datasets/pxcorpus" # local path
     subset: "French"
     source_split: "train"
-    target_split: 
+    target_split: "train"
     commercial_use: False
     comment: ""
   - source: MQC
     path: "datasets/mqc" # local path
     subset: "French"
     source_split: "train"
-    target_split: 
+    target_split: "train"
     commercial_use: False
     comment: ""

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import os
+import json
 import datetime
 import tempfile
 import pandas as pd
@@ -20,8 +21,8 @@ def main():
     all_cfg = load_config(args=args)
 
     stats = {}
-    global_ds = []
     commit_files = {}
+    split_file = {"train": [], "test": []}
 
     for cfg in all_cfg:
         all_ds = []
@@ -54,10 +55,10 @@ def main():
             merged = concatenate_datasets(all_ds)
             print(type(merged))
             print(f"Shape of concatenated dataset: {merged.shape}")
-            global_ds.append(merged)
             if args.push_to_hub:
                 msg = generate_info_file(dataset=merged, source_name=cfg['source'], source_split=cfg['source_split'], comment=cfg['comment'], stats=stats[cfg['source']])
-                commit_files[cfg['source']] = [msg, concatenate_datasets(all_ds)] # cfg['target_split']]
+                commit_files[cfg['source']] = [msg, merged,  cfg['target_split']]
+                split_file[cfg['target_split']].append(cfg['source'])
         else:
             print(f"No data was loaded for dataset \"{cfg['source']}\".")
             raise ValueError()
@@ -69,10 +70,10 @@ def main():
             clone_from="LIMICS/PARTAGES" if args.make_commercial_version else "LIMICS/PARTAGES-research",
             repo_type="dataset",
         )
-
+        # Dictionary commit_files is empty if not args.push_to_hub (see rows 58-60)
         for key, val in commit_files.items():
-            if not os.path.exists(os.path.join(tmpdir, key)):
-                os.makedirs(os.path.join(tmpdir, key))
+            # if not os.path.exists(os.path.join(tmpdir, key)):
+            os.makedirs(os.path.join(tmpdir, key), exist_ok=True)
             # Writing and saving info file
             info_file_name = f"{key}/{key}_info.md"
             info_file = os.path.join(tmpdir, info_file_name)
@@ -85,8 +86,8 @@ def main():
             val[1].to_parquet(df_file)
             repo.git_add(df_file_name)
         
-        stats_path = Path(tmpdir) / "dataset_stats.csv"
-        if not args.use_all_sources and os.path.exists(Path(tmpdir) / "dataset_stats.csv"):
+        stats_path = os.path.join(tmpdir, "dataset_stats.csv")
+        if not args.use_all_sources and os.path.exists(stats_path):
             df = pd.read_csv(stats_path, index_col=0)
             df.drop("Total", inplace=True)
             df[args.source] = stats[args.source]
@@ -96,11 +97,32 @@ def main():
             df = pd.DataFrame(list(stats.values()), index=list(stats.keys()))
             compute_global_stats(df=df)
             df.to_csv(stats_path, index=True)
-        repo.git_add(stats_path)
         
-        commit_msg = f"Updating dataset on {datetime.date.today().isoformat()}." if args.use_all_sources else f"Updating corpus {all_cfg[0]['source']} on {datetime.date.today().isoformat()}."
-        repo.git_commit(commit_message=commit_msg)
-        repo.git_push()
+        split_path = os.path.join(tmpdir, "split.json")
+        if not args.use_all_sources and os.path.exists(split_path):
+            with open(split_path, 'r') as f:
+                old_split_file = json.load(f)
+            if not ((args.name in old_split_file['train']) or (args.name in old_split_file['test'])):
+                old_split_file['test'].append(args.name) if (args.name in split_file['test']) else old_split_file['train'].append(args.name)
+            else:
+                if (args.name in old_split_file['train']) and (args.name in split_file['test']):
+                    old_split_file['train'].remove(args.name)
+                    old_split_file['test'].append(args.name)
+                elif (args.name in old_split_file['test']) and (args.name in split_file['train']):
+                    old_split_file['test'].remove(args.name)
+                    old_split_file['train'].append(args.name)
+            with open(split_path, 'w') as f:
+                json.dump(old_split_file, f, indent=4)
+        else:
+            with open(split_path, 'w') as f:
+                json.dump(split_file, f, indent=4)
+
+        if args.push_to_hub:
+            repo.git_add(stats_path)
+            repo.git_add(split_path)
+            commit_msg = f"Updating dataset on {datetime.date.today().isoformat()}." if args.use_all_sources else f"Updating corpus {all_cfg[0]['source']} on {datetime.date.today().isoformat()}."
+            repo.git_commit(commit_message=commit_msg)
+            repo.git_push()
 
     with pd.option_context('display.max_columns', None, 'display.width', 0):
         print(df)


### PR DESCRIPTION
- Implementation to save the wanted train/test split to a split.json file which is read when reading the dataset with datasets.load_dataset to create the split.
- Split is made based on a `"target_split"` key in `config/datasets.yaml`.