### PR TITLE
Adding casting for null columns to string when loading remote/local data.

### DIFF
--- a/loaders/utils.py
+++ b/loaders/utils.py
@@ -11,7 +11,14 @@ import numpy as np
 import pandas as pd
 import yaml
 
-from datasets import Dataset, DatasetDict, IterableDataset, arrow_dataset
+from datasets import (
+    Dataset,
+    DatasetDict,
+    Features,
+    IterableDataset,
+    Value,
+    arrow_dataset,
+)
 from src.text_cleaning import cleaner
 
 logger = logging.getLogger(__name__)
@@ -513,3 +520,13 @@ def clean_example(
         example["text"], do_lower=lower, rm_new_lines=rm_new_lines
     )
     return example
+
+
+def cast_columns(
+    dataset: Dataset,
+) -> Dataset:
+    new_features = dataset.features.copy()
+    for col, feature in new_features.items():
+        if feature.dtype == "null":
+            new_features[col] = Value("string")
+    return dataset.cast(Features(new_features))

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from huggingface_hub import HfFolder, Repository, login
 from datasets import concatenate_datasets
 from loaders import REGISTRY
 from loaders.utils import (
+    cast_columns,
     compute_dataset_stats,
     compute_global_stats,
     generate_info_file,
@@ -70,6 +71,7 @@ def main():
                     source_split=split,
                 )
                 ds = loader.load()
+                ds = cast_columns(ds)
                 row = compute_dataset_stats(
                     dataset=ds,
                     source_name=cfg["source"],
@@ -86,6 +88,7 @@ def main():
         if all_ds:
             # Concatenate all subsets and splits for a single source
             merged = concatenate_datasets(all_ds)
+            logger.info(f"Features scheme of concatenated dataset: {merged.features}")
             logger.info(f"Shape of concatenated dataset: {merged.shape}")
             logger.debug(f"Type of concatenated datasets: {type(merged)}")
             # Remove empty rows


### PR DESCRIPTION
Pour pouvoir utiliser datasets > 4.0.0 sur les datasets *-sourced s'assurer que les colonnes (`Features`) sans valeurs (pas de subset ou de split) de type null soient converties vers un dtype Value("string")pour débugger les erreurs de schéma lors du chargement des données avec load_dataset sans loader custom.

→ fonction cast_column(dataset) dans [utils.py](http://utils.py/)  appliqué après chaque collect de split/subset